### PR TITLE
fix: remove redundant `import moproFFI`

### DIFF
--- a/ios/MoproReactNativePackageModule.swift
+++ b/ios/MoproReactNativePackageModule.swift
@@ -1,5 +1,4 @@
 import ExpoModulesCore
-import moproFFI
 
 // Modify generateProof to return the full CircomProofResult structure directly
 // Expo Modules should handle the serialization of the moproFFI.CircomProofResult struct


### PR DESCRIPTION
**fix: remove redundant import of moproFFI**

mopro.swift already imports moproFFI, and makes the wrapped bindings available project-wide. As no other file references moproFFI directly, instead, using the wrapped logic, the extra import introduces complexity and blocks support of multiple Mopro generated bindings in a single project.